### PR TITLE
feat: return more info about the calculation when fetching apy

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,9 +14,12 @@ import { fetchAndParsePricesCsv, calcAverageApy, DATA_SOURCE } from '@glitchful-
 
 (async () => {
   const prices = await fetchAndParsePricesCsv(DATA_SOURCE.MARINADE_CSV)
-  const apy = calcAverageApy(prices)
+  const result = calcAverageApy(prices)
 
-  console.log(apy) // 0.06267310505366575 => 6.267 %
+  console.log('apy: ', result?.apy);                        // 0.06422106873309597 => 6.422 %
+  console.log('timestampStart: ', result?.timestampStart);  // 1676577600000 => Thursday, February 16, 2023 8:00:00 PM GMT+00:00
+  console.log('timestampEnd: ', result?.timestampEnd);      // 1678686963000 => Monday, March 13, 2023 5:56:03 AM GMT+00:00
+  console.log('epochs used for calc: ', result?.epochs);    // 10
 })()
 ```
 

--- a/packages/sol-apy-sdk/index.ts
+++ b/packages/sol-apy-sdk/index.ts
@@ -26,6 +26,13 @@ export type PriceRecord = {
   price: number;
 };
 
+export type ApyCalcResult = {
+  timestampStart: number;
+  timestampEnd: number;
+  epochs: number;
+  apy: number;
+};
+
 export const parsePriceRecordsFromCSV = async (
   csv: Readable
 ): Promise<PriceRecord[]> => {
@@ -67,7 +74,7 @@ export const fetchAndParsePricesCsv = async (url: string) => {
 export const calcAverageApy = (
   priceRecords: PriceRecord[],
   epochs = DEFAULT_EPOCHS
-): number | null => {
+): ApyCalcResult | null => {
   priceRecords.sort((a, b) => b.timestamp - a.timestamp);
 
   if (priceRecords.length <= 1) {
@@ -82,11 +89,12 @@ export const calcAverageApy = (
 
   let timestampStart = timestampEnd;
   let priceStart = priceEnd;
+  let epochStart = epochEnd;
 
   for (const {timestamp, epoch, price} of priceRecords) {
     timestampStart = timestamp;
     priceStart = price;
-
+    epochStart = epoch;
     if (epochEnd - epoch >= epochs) {
       break;
     }
@@ -100,5 +108,10 @@ export const calcAverageApy = (
     return null;
   }
 
-  return priceChange ** (millisecondsInAYear / deltaMilliseconds) - 1;
+  return {
+    apy: priceChange ** (millisecondsInAYear / deltaMilliseconds) - 1,
+    epochs: epochEnd - epochStart,
+    timestampStart: timestampStart,
+    timestampEnd: timestampEnd,
+  };
 };


### PR DESCRIPTION
make `calcAverageApy` to return more information on what data were used to get apy:

```
ApyCalcResult = {
  startTimestamp: number;
  endTimestamp: number;
  epochs: number;
  apy: number;
}
```