### PR TITLE
fix: make it possible to use PERIOD enum

### DIFF
--- a/packages/sol-apy-sdk/index.ts
+++ b/packages/sol-apy-sdk/index.ts
@@ -72,11 +72,11 @@ export const fetchAndParsePricesCsv = async (url: string) => {
 };
 
 const enum SECONDS_PER {
-  DAY =  24 * 3600,
+  DAY = 24 * 3600,
   YEAR = 365.25 * 24 * 3600
 }
 
-export const enum PERIOD {
+export enum PERIOD {
   DAYS_7 = 7 * SECONDS_PER.DAY,
   DAYS_14 = 14 * SECONDS_PER.DAY,
   DAYS_30 = 30 * SECONDS_PER.DAY,

--- a/packages/sol-apy-sdk/package.json
+++ b/packages/sol-apy-sdk/package.json
@@ -2,7 +2,7 @@
     "author": {
         "name": "Jan Legner"
     },
-    "version": "3.0.0",
+    "version": "3.0.1",
     "main": "index.js",
     "types": "./index.d.ts",
     "license": "UNLICENCED",


### PR DESCRIPTION
Getting this error when trying to import `PERIOD`
``` 
Cannot access ambient const enums when 'isolatedModules' is enabled.ts(2748)
```